### PR TITLE
Fix lava new exiting code 1 on EOF after note creation

### DIFF
--- a/lava/commands/notes.py
+++ b/lava/commands/notes.py
@@ -84,7 +84,10 @@ def cmd_new(
     note_path = vlt.create_note(current, name, body="", links=[], frontmatter_extra=extra)
     ui.print_success(f"Created: {note_path}")
 
-    open_after = Confirm.ask("Open in editor?", default=False)
+    try:
+        open_after = Confirm.ask("Open in editor?", default=False)
+    except (EOFError, KeyboardInterrupt):
+        raise typer.Exit(0)
     if open_after:
         editor_cfg = config.get("editor", "")
         start = ed.last_line(note_path)


### PR DESCRIPTION
After successfully creating a note, the "Open in editor?" prompt raised an unhandled EOFError when stdin was closed (scripts/pipes), causing exit code 1. Catches EOFError and KeyboardInterrupt and exits 0 — the note was already created successfully.